### PR TITLE
Allocating response buffer based on body size and on header size when…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,8 @@ add_dependencies(hello_world haywire)
 target_link_libraries (hello_world
     ${haywire_location}
     ${CMAKE_SOURCE_DIR}/lib/libuv/.libs/libuv.a
-    ${CMAKE_THREAD_LIBS_INIT})
+    ${CMAKE_THREAD_LIBS_INIT}
+    -lm)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     target_link_libraries (hello_world rt)

--- a/src/haywire/http_response.c
+++ b/src/haywire/http_response.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <math.h>
 #include "http_response.h"
 #include "http_response_cache.h"
 #include "haywire.h"
@@ -66,13 +67,30 @@ hw_string* create_response_buffer(hw_http_response* response)
 
     int i = 0;
 
-    response_string->value = calloc(1024, 1);
+    char length_header[] = "Content-Length: ";
+    int line_sep_size = sizeof(CRLF);
+
+    int header_buffer_incr = 1024;
+    int body_size = resp->body.length + line_sep_size;
+    int header_size_remaining = header_buffer_incr;
+    int response_size = header_size_remaining + sizeof(length_header) + (int)(log10(resp->body.length) + 1) + 2 * line_sep_size + body_size + line_sep_size;
+
+    response_string->value = calloc(response_size, 1);
+
     response_string->length = 0;
     append_string(response_string, cached_entry);
     
     for (i=0; i< resp->number_of_headers; i++)
     {
         http_header header = resp->headers[i];
+
+        header_size_remaining -= strlen(header.name.value) + 2 + strlen(header.value.value) + line_sep_size;
+        if (header_size_remaining < 0) {
+            header_size_remaining += header_buffer_incr * ((-header_size_remaining/header_buffer_incr) + 1);
+            response_size += header_size_remaining;
+            realloc(response_string->value, response_size);
+        }
+
         append_string(response_string, &header.name);
         APPENDSTRING(response_string, ": ");
         append_string(response_string, &header.value);
@@ -80,9 +98,9 @@ hw_string* create_response_buffer(hw_http_response* response)
     }
     
     /* Add the body */
-    APPENDSTRING(response_string, "Content-Length: ");
-    
-    string_from_int(&content_length, resp->body.length + 3, 10);
+    APPENDSTRING(response_string, length_header);
+
+    string_from_int(&content_length, body_size, 10);
     append_string(response_string, &content_length);
     APPENDSTRING(response_string, CRLF CRLF);
     


### PR DESCRIPTION
… required and not just statically. Fixes #54.

By default, it will allocate 1K for the headers, but it will reallocate as necessary if the headers take more than 1k.
